### PR TITLE
fix: Change trust limit

### DIFF
--- a/src/operations/change_trust.rs
+++ b/src/operations/change_trust.rs
@@ -117,7 +117,7 @@ impl ChangeTrustOperationBuilder {
             .ok_or_else(|| Error::InvalidOperation("missing change trust asset".to_string()))?;
 
         if let Some(limit) = &self.limit {
-            if limit.to_i64() <= 0 {
+            if limit.to_i64() < 0 {
                 return Err(Error::InvalidOperation(
                     "change trust limit must be positive".to_string(),
                 ));


### PR DESCRIPTION
# Issue
There is no way to remove a trust line.

# Fix
Update the change trust operation limit check to allow a 0 limit, to be able to remove trust lines.
This fix is trivial, update the limit check in the `ChangeTrustOprationBuilder` `build()` function.

```rust
// Change `<=` to `<` to be able to remove trust lines
if limit.to_i64() <= 0 { 
	return Err(Error::InvalidOperation(
		"change trust limit must be positive".to_string(),
	));
}
```