### PR TITLE
Update new_from_preimage to use hash for hint

### DIFF
--- a/src/crypto/signature.rs
+++ b/src/crypto/signature.rs
@@ -117,7 +117,8 @@ impl DecoratedSignature {
 
     /// Creates a new `DecoratedSignature` from the pre image.
     pub fn new_from_preimage(preimage: &[u8]) -> Result<DecoratedSignature> {
-        let hint = SignatureHint::from_slice(&preimage[preimage.len() - 4..])?;
+        let hash = hash(preimage);
+        let hint = SignatureHint::from_slice(&hash[hash.len() - 4..])?;
         let signature = Signature::from_slice(preimage).map_err(|_| Error::InvalidSignature)?;
         Ok(DecoratedSignature::new(hint, signature))
     }


### PR DESCRIPTION
Core matches the hash of the preimage in order to validate a HashX signature.

Note: this was in 0.6.0 as well. BTW, thank you for this library. I like it a lot.